### PR TITLE
Create parent directores when creating log directory.

### DIFF
--- a/train.py
+++ b/train.py
@@ -306,7 +306,7 @@ def _train_dataset(subdir:Optional[str], param_txt:List[str],
 
     if subdir is not None:
         output_dir = output_dir / subdir
-        output_dir.mkdir()
+        output_dir.mkdir(parents=True)
 
     torch.save(net.state_dict(), output_dir/"initial_net.zip")
 


### PR DESCRIPTION
If output subdirectors are given in train.retrain(), then the code crashes because their parents are not created.