### PR TITLE
Remove unreferenced files

### DIFF
--- a/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-000-phase_1/final_net.zip
+++ b/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-000-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a34f6e1abfc5832469837aa88ba5bb92f7d364ebedf70a82430bfac7cc4ab5f5
-size 6089128

--- a/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-001-phase_1/final_net.zip
+++ b/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-001-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1da63f1433b6906c2ce565eda88de4c2553edcfbd7a3af521ac279fe0fbc4787
-size 6089128

--- a/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-002-phase_1/final_net.zip
+++ b/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-002-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:11f9b608a821641b4712de86e2273b4b809a04a5d792a7aa07a7761382c9eede
-size 6089128

--- a/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-003-phase_1/final_net.zip
+++ b/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-003-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cfe03537be6c4f295d4b0ea30a31d7f0f2edec79b50d78cc7ed1ea262083fcec
-size 6089128

--- a/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-004-phase_1/final_net.zip
+++ b/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-004-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc549897b7ffdb099973be1ee6a30d77eef7b2f40a88c5e8824f599106ec2891
-size 6089128

--- a/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-005-phase_1/final_net.zip
+++ b/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-005-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f94e5fa6e7be4db1f4bab4d355fa756b1dfe37a118d518356ae28ebb72e2444
-size 6089128

--- a/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-006-phase_1/final_net.zip
+++ b/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-006-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6331e02f0d4e254599b6b8f79249e473796087bce4cf4464c5e60bb79c158197
-size 6089128

--- a/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-007-phase_1/final_net.zip
+++ b/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-007-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5bde5a999fe2a879ee48a1b7d960d30d82d9481113813c08cebdd3271d0bc26
-size 6089128

--- a/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-008-phase_1/final_net.zip
+++ b/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-008-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a1d870b048542d0e88d9db759be27481256c34088d79fc3f9691de48eb7b55f3
-size 6089128

--- a/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-009-phase_1/final_net.zip
+++ b/sample_logs/1747339102-dade47db81422098a8f9fff9af4f95ff1bb39500/run-009-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:39a241d026013dd31297d91d4112d006ac1f39936fb9267ed4f1cf173d3cd6e3
-size 6089128

--- a/sample_logs/1747596426-981c285635c0a429e4428b4bbae8c6e2f130ce53/run-000-phase_0/final_net.zip
+++ b/sample_logs/1747596426-981c285635c0a429e4428b4bbae8c6e2f130ce53/run-000-phase_0/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:418d3a92e55ef23a4e5642de1037c7e47b928e25586f2a8be0469273883eb546
-size 6087072

--- a/sample_logs/1747596426-981c285635c0a429e4428b4bbae8c6e2f130ce53/run-000-phase_0/loss.txt.xz
+++ b/sample_logs/1747596426-981c285635c0a429e4428b4bbae8c6e2f130ce53/run-000-phase_0/loss.txt.xz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:805363177f091049efe6ac7d5ca22c17841616363eea86039992d271f66eb12a
-size 35549336

--- a/sample_logs/1748018915-fdf7a45f7f8927faa7adf19f9ea2d8359aaf7527-final_net-utubule.zip
+++ b/sample_logs/1748018915-fdf7a45f7f8927faa7adf19f9ea2d8359aaf7527-final_net-utubule.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5533d51499c105ac2221abc55a3690be1a616d25d334ead78ef808b159c9acf9
-size 6087473

--- a/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-000-phase_1/final_net.zip
+++ b/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-000-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e76901f6afd3603bbcda91b3f5c88dfb7d86ab58871cf8422d52926e2f7f0ed9
-size 6089529

--- a/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-001-phase_1/final_net.zip
+++ b/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-001-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce90511efb3150d73cfb28d161cb782ccd51c0ad8602ba133f702fd6c15edada
-size 6089529

--- a/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-002-phase_1/final_net.zip
+++ b/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-002-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:85b12e323ed442b24cebf9eb1b9542c2c073f09096fbcc863fc816b46990506f
-size 6089529

--- a/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-003-phase_1/final_net.zip
+++ b/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-003-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c375f33169304b9581d357dbb35c7eb192eae8ba4ea6d4b1f6a907be2e57b40
-size 6089529

--- a/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-004-phase_1/final_net.zip
+++ b/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-004-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:33737325d07dafb2c62c261baf5f20b0f87a0fa26e5d65ab36c5a4b1f30c0614
-size 6089529

--- a/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-005-phase_1/final_net.zip
+++ b/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-005-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa2f77acc09e1c3892af669344e62a99f1d67ac1f989ba8cea200a8c2a5165ba
-size 6089529

--- a/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-006-phase_1/final_net.zip
+++ b/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-006-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eb61e22b7c928be6943d17634510f4a95fa052fa729e9b3d3884fe860acbab1a
-size 6089529

--- a/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-007-phase_1/final_net.zip
+++ b/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-007-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9bb314bf8d3bc5221415d42f1dcd683cb1084e570f964c540bedb3d5a36a3dd4
-size 6089529

--- a/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-008-phase_1/final_net.zip
+++ b/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-008-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b824d0ab4bd57dc109dd4ac666ceb661b96d39808d5c6569c32f02bda1c10c62
-size 6089529

--- a/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-009-phase_1/final_net.zip
+++ b/sample_logs/1748256957-20357f6e0747c236a9bb79141ff5218fbbd16b6f/run-009-phase_1/final_net.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ddb0a5f7405768e2f9caacdcbc627106c70ddde6f951d95776680e3fa616242
-size 6089529


### PR DESCRIPTION
There were a number of log files stored in sample_logs which were not referenced by any of the plotting or analysis scripts. Removing these save about 160M of download on a clone. 