### PR TITLE
Fix missing import in train_nupc_simple.ipynb

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Ruff
         run: |
-          ruff check data/ train*.py  figure_2_plot_nupc.py  figure_3_plot_nupc.py 
+          ruff check data/ train*.py  figure_2_plot_nupc.py  figure_3_plot_nupc.py  train_nupc_simple.ipynb
 
       - name: pylint
         run: |

--- a/train_nupc_simple.ipynb
+++ b/train_nupc_simple.ipynb
@@ -31,7 +31,7 @@
     "# these are the imports for the data\n",
     "# you will need to adapt one of these if you want to import your own data\n",
     "import resi_data\n",
-    "import mark_bates_data\n",
+    "import mark_bates_data # noqa\n",
     "\n",
     "# here we are importing the specific training information, network architecture and device\n",
     "import train\n",
@@ -435,6 +435,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import matplotlib.pyplot as plt\n",
     "plt.hist(scales[:,0], 30)\n",
     "plt.xlabel('Relative scaling of the underlying model in Z')\n",
     "plt.ylabel('Count')"


### PR DESCRIPTION
An import went missing.

Also apparently Ruff can check notebooks, so add it to the ruff list!