### PR TITLE
Change default meshing chunk size to 100 for all functions

### DIFF
--- a/save_ply.py
+++ b/save_ply.py
@@ -78,7 +78,7 @@ def make_mesh(data:torch.Tensor, weights: torch.Tensor, sigma: float, threshold:
     return verts, faces
 
 
-def save_pointcloud_as_mesh(filename: Union[Path, str], data:torch.Tensor, weights: torch.Tensor, sigma: float, threshold:float=0.1, size:int=100, colour:tuple[int,int,int,int]=(127,127,127,255), comments: str="", maxval: None|float=None, chunksize:int=1000000)->None:
+def save_pointcloud_as_mesh(filename: Union[Path, str], data:torch.Tensor, weights: torch.Tensor, sigma: float, threshold:float=0.1, size:int=100, colour:tuple[int,int,int,int]=(127,127,127,255), comments: str="", maxval: None|float=None, chunksize:int=100)->None:
     """Mesh a set of 3D points and save as a ply file"""
 
     with open(filename, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
https://github.com/edrosten/SQUASSH/commit/51115254dc2255c0901c240ef724f9018bf2c2dd amended meshing to use chunks of points rather than the entire model at once in order to allow saving of meshes on GPUs with smaller amounts of RAM.

The change was only applied to the new `make_mesh` function. This PR applies the same change to all mesh saving functions i.e. `save_pointcloud_as_mesh`. This gives the same robustness to all parts of the codebase, not just the notebook.